### PR TITLE
Perform logical replication after initial sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/bitnami/postgresql:12
+
+# Install wal2json
+USER root
+RUN install_packages curl ca-certificates gnupg && \
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    install_packages postgresql-12-wal2json && \
+    cp /usr/lib/postgresql/12/lib/wal2json.so /opt/bitnami/postgresql/lib/wal2json.so
+USER 1001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,17 @@ version: "3.3"
 
 services:
   db_primary:
-    image: "docker.io/bitnami/postgresql:12"
+    build: .
     container_name: "primary"
     ports:
       - "5432:5432"
     environment:
       - POSTGRESQL_REPLICATION_MODE=master
-      - POSTGRESQL_REPLICATION_USER=repl_user
-      - POSTGRESQL_REPLICATION_PASSWORD=repl_password
-      - POSTGRES_USER=test_user
-      - POSTGRES_PASSWORD=my-secret-passwd
+      - POSTGRESQL_REPLICATION_USER=test_user
+      - POSTGRESQL_REPLICATION_PASSWORD=my-secret-passwd
       - POSTGRESQL_POSTGRES_PASSWORD=my-secret-passwd
       - POSTGRESQL_DATABASE=tap_postgres_test
+      - POSTGRESQL_WAL_LEVEL=logical
       - ALLOW_EMPTY_PASSWORD=yes
   db_replica:
     image: "docker.io/bitnami/postgresql:12"
@@ -24,8 +23,8 @@ services:
       - db_primary
     environment:
       - POSTGRESQL_REPLICATION_MODE=slave
-      - POSTGRESQL_REPLICATION_USER=repl_user
-      - POSTGRESQL_REPLICATION_PASSWORD=repl_password
+      - POSTGRESQL_REPLICATION_USER=test_user
+      - POSTGRESQL_REPLICATION_PASSWORD=my-secret-passwd
       - POSTGRESQL_MASTER_HOST=db_primary
       - POSTGRESQL_MASTER_PORT_NUMBER=5432
       - ALLOW_EMPTY_PASSWORD=yes

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -131,6 +131,8 @@ def sync_method_for_streams(streams, state, default_replication_method):
             # finishing previously interrupted full-table (first stage of logical replication)
             lookup[stream['tap_stream_id']] = 'logical_initial_interrupted'
             traditional_steams.append(stream)
+            # do any required logical replication after inital sync is complete
+            logical_streams.append(stream)
 
         # inconsistent state
         elif get_bookmark(state, stream['tap_stream_id'], 'xmin') and \
@@ -142,6 +144,8 @@ def sync_method_for_streams(streams, state, default_replication_method):
             # initial full-table phase of logical replication
             lookup[stream['tap_stream_id']] = 'logical_initial'
             traditional_steams.append(stream)
+            # do any required logical replication after inital sync is complete
+            logical_streams.append(stream)
 
         else:  # no xmin but we have an lsn
             # initial stage of logical replication(full-table) has been completed. moving onto pure logical replication

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -2,6 +2,7 @@ import psycopg2
 import unittest.mock
 import pytest
 import tap_postgres
+from tap_postgres.sync_strategies import logical_replication
 import tap_postgres.sync_strategies.full_table as full_table
 import tap_postgres.sync_strategies.common as pg_common
 import singer
@@ -48,10 +49,28 @@ tap_postgres.dump_catalog = do_not_dump_catalog
 full_table.UPDATE_BOOKMARK_PERIOD = 1
 
 @pytest.mark.parametrize('use_secondary', [False, True])
-@unittest.mock.patch('tap_postgres.sync_logical_streams')
+@unittest.mock.patch('tap_postgres.sync_logical_streams', wraps=tap_postgres.sync_logical_streams)
 @unittest.mock.patch('psycopg2.connect', wraps=psycopg2.connect)
 class TestLogicalInterruption:
     maxDiff = None
+
+    def setup_class(self):
+        conn_config = get_test_connection_config()
+        slot_name = logical_replication.generate_replication_slot_name(
+            dbname=conn_config['dbname'], tap_id=conn_config['tap_id']
+        )
+        with get_test_connection(superuser=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT * FROM pg_create_logical_replication_slot('{slot_name}', 'wal2json')")
+
+    def teardown_class(self):
+        conn_config = get_test_connection_config()
+        slot_name = logical_replication.generate_replication_slot_name(
+            dbname=conn_config['dbname'], tap_id=conn_config['tap_id']
+        )
+        with get_test_connection(superuser=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT * FROM pg_drop_replication_slot('{slot_name}')")
 
     def setup_method(self):
         table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
@@ -75,7 +94,16 @@ class TestLogicalInterruption:
         streams = tap_postgres.do_discovery(conn_config)
 
         # Assert that we connected to the correct database
-        expected_connection = {
+        primary_connection = {
+            'application_name': unittest.mock.ANY,
+            'dbname': unittest.mock.ANY,
+            'user': unittest.mock.ANY,
+            'password': unittest.mock.ANY,
+            'connect_timeout':unittest.mock.ANY,
+            'host': conn_config['host'],
+            'port': conn_config['port'],
+        }
+        secondary_connection = {
             'application_name': unittest.mock.ANY,
             'dbname': unittest.mock.ANY,
             'user': unittest.mock.ANY,
@@ -84,8 +112,8 @@ class TestLogicalInterruption:
             'host': conn_config['secondary_host'] if use_secondary else conn_config['host'],
             'port': conn_config['secondary_port'] if use_secondary else conn_config['port'],
         }
-        mock_connect.assert_called_once_with(**expected_connection)
-        mock_connect.reset_mock()
+
+        mock_connect.assert_called_once_with(**secondary_connection)
 
         cow_stream = [s for s in streams if s['table_name'] == 'COW'][0]
         assert cow_stream is not None
@@ -114,6 +142,7 @@ class TestLogicalInterruption:
         state = {}
         #the initial phase of cows logical replication will be a full table.
         #it will sync the first record and then blow up on the 2nd record
+        mock_connect.reset_mock()
         try:
             tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, state)
         except Exception:
@@ -121,10 +150,12 @@ class TestLogicalInterruption:
 
         assert blew_up_on_cow is True
 
-        mock_connect.assert_called_with(**expected_connection)
-        mock_connect.reset_mock()
-
         mock_sync_logical_streams.assert_not_called()
+
+        mock_connect.assert_has_calls(
+            [unittest.mock.call(**primary_connection)] * 2 + \
+            [unittest.mock.call(**secondary_connection)] * 4
+        )
 
         assert 7 == len(CAUGHT_MESSAGES)
 
@@ -173,15 +204,17 @@ class TestLogicalInterruption:
         global COW_RECORD_COUNT
         COW_RECORD_COUNT = 0
         CAUGHT_MESSAGES.clear()
-        tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, old_state)
-
-        mock_connect.assert_called_with(**expected_connection)
         mock_connect.reset_mock()
+        tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, old_state)
 
         mock_sync_logical_streams.assert_called_once()
 
+        mock_connect.assert_has_calls(
+            [unittest.mock.call(**primary_connection)] * 2 + \
+            [unittest.mock.call(**secondary_connection)] * 4
+        )
 
-        assert 8 == len(CAUGHT_MESSAGES)
+        assert 10 == len(CAUGHT_MESSAGES)
 
         assert CAUGHT_MESSAGES[0]['type'] == 'SCHEMA'
 
@@ -229,6 +262,13 @@ class TestLogicalInterruption:
         assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('xmin') is None
         assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('lsn') == end_lsn
         assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('version') == new_version
+
+        assert CAUGHT_MESSAGES[8]['type'] == 'SCHEMA'
+
+        assert isinstance(CAUGHT_MESSAGES[9], singer.messages.StateMessage)
+        assert CAUGHT_MESSAGES[9].value['bookmarks']['public-COW'].get('xmin') is None
+        assert CAUGHT_MESSAGES[9].value['bookmarks']['public-COW'].get('lsn') == end_lsn
+        assert CAUGHT_MESSAGES[9].value['bookmarks']['public-COW'].get('version') == new_version
 
 @pytest.mark.parametrize('use_secondary', [False, True])
 @unittest.mock.patch('psycopg2.connect', wraps=psycopg2.connect)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,11 @@ def get_test_connection_config(target_db='postgres', use_secondary=False):
     if len(missing_envs) != 0:
         raise Exception("set TAP_POSTGRES_HOST, TAP_POSTGRES_USER, TAP_POSTGRES_PASSWORD, TAP_POSTGRES_PORT")
 
-    conn_config = {'host': os.environ.get('TAP_POSTGRES_HOST'),
+    conn_config = {'tap_id': 'test-postgres',
+                   'max_run_seconds': 5,
+                   'break_at_end_lsn': True,
+                   'logical_poll_total_seconds': 2,
+                   'host': os.environ.get('TAP_POSTGRES_HOST'),
                    'user': os.environ.get('TAP_POSTGRES_USER'),
                    'password': os.environ.get('TAP_POSTGRES_PASSWORD'),
                    'port': os.environ.get('TAP_POSTGRES_PORT'),


### PR DESCRIPTION
## Problem

If you select new tables to add to an existing log based extract, it'll do a "logical_initial" full table sync on those new tables each and every time the tap runs. It'll never switch over to log based replication for them.

Another example of this issue is that if intend to run with `break_at_end_lsn is False` then I have to run the tap twice - once to perform the initial sync and again to start the logical replication.

## Proposed changes

This Pull Request contains changes which are simpler and, I believe, more correct than those in #130. Both Pull Requests aim to solve #107. 

My changes ensure that whenever a `LOG_BASED` replication runs the bookmark is initialised correctly and any logical replication which is required is performed.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
